### PR TITLE
correct other import paths in CI and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
   - 1.5
   - 1.6
 
-go_import_path: github.com/mattes/migrate
+go_import_path: github.com/gemnasium/migrate
 
 services:
   - docker

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMAGE=mattes/migrate
+IMAGE=gemnasium/migrate
 DCR=docker-compose run --rm
 .PHONY: clean test build release docker-build docker-push run
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 go: &go
   image: golang
-  working_dir: /go/src/github.com/mattes/migrate
+  working_dir: /go/src/github.com/gemnasium/migrate
   volumes:
     - $GOPATH:/go
 go-test:


### PR DESCRIPTION
Without this, the tests pass (or fail) because of what you have checked out locally as github.com/mattes/migrate.
