### PR TITLE
make timestamp versioning backwards compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
   - 1.5
   - 1.6
 
-go_import_path: github.com/mattes/migrate
+go_import_path: github.com/gemnasium/migrate
 
 services:
   - docker

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMAGE=mattes/migrate
+IMAGE=gemnasium/migrate
 DCR=docker-compose run --rm
 .PHONY: clean test build release docker-build docker-push run
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 go: &go
   image: golang
-  working_dir: /go/src/github.com/mattes/migrate
+  working_dir: /go/src/github.com/gemnasium/migrate
   volumes:
     - $GOPATH:/go
 go-test:

--- a/driver/mysql/mysql_test.go
+++ b/driver/mysql/mysql_test.go
@@ -25,15 +25,11 @@ func TestMigrate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := connection.Exec(`DROP TABLE IF EXISTS yolo, yolo1, ` + tableName); err != nil {
-		t.Fatal(err)
-	}
+	dropTestTables(t, connection)
 
 	migrate(t, driverUrl)
 
-	if _, err := connection.Exec(`DROP TABLE IF EXISTS yolo, yolo1, ` + tableName); err != nil {
-		t.Fatal(err)
-	}
+	dropTestTables(t, connection)
 
 	// Make an old-style 32-bit int version column that we'll have to upgrade.
 	_, err = connection.Exec("CREATE TABLE IF NOT EXISTS " + tableName + " (version int not null primary key);")
@@ -142,6 +138,12 @@ func migrate(t *testing.T, driverUrl string) {
 	}
 
 	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func dropTestTables(t *testing.T, db *sql.DB) {
+	if _, err := db.Exec(`DROP TABLE IF EXISTS yolo, yolo1, ` + tableName); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/driver/mysql/mysql_test.go
+++ b/driver/mysql/mysql_test.go
@@ -29,6 +29,22 @@ func TestMigrate(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	migrate(t, driverUrl)
+
+	if _, err := connection.Exec(`DROP TABLE IF EXISTS yolo, yolo1, ` + tableName); err != nil {
+		t.Fatal(err)
+	}
+
+	// Make an old-style 32-bit int version column that we'll have to upgrade.
+	_, err = connection.Exec("CREATE TABLE IF NOT EXISTS " + tableName + " (version int not null primary key);")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	migrate(t, driverUrl)
+}
+
+func migrate(t *testing.T, driverUrl string) {
 	d := &Driver{}
 	if err := d.Initialize(driverUrl); err != nil {
 		t.Fatal(err)
@@ -63,8 +79,8 @@ func TestMigrate(t *testing.T) {
 		},
 		{
 			Path:      "/foobar",
-			FileName:  "20060102150405_foobar.up.sql",
-			Version:   20060102150405,
+			FileName:  "20070000000000_foobar.up.sql",
+			Version:   20070000000000,
 			Name:      "foobar",
 			Direction: direction.Up,
 			Content: []byte(`

--- a/driver/postgres/postgres_test.go
+++ b/driver/postgres/postgres_test.go
@@ -23,19 +23,12 @@ func TestMigrate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := connection.Exec(`
-				DROP TABLE IF EXISTS yolo;
-				DROP TABLE IF EXISTS ` + tableName + `;`); err != nil {
-		t.Fatal(err)
-	}
+
+	dropTestTables(t, connection)
 
 	migrate(t, driverUrl)
 
-	if _, err := connection.Exec(`
-				DROP TABLE IF EXISTS yolo;
-				DROP TABLE IF EXISTS ` + tableName + `;`); err != nil {
-		t.Fatal(err)
-	}
+	dropTestTables(t, connection)
 
 	// Make an old-style `int` version column that we'll have to upgrade.
 	_, err = connection.Exec("CREATE TABLE IF NOT EXISTS " + tableName + " (version int not null primary key)")
@@ -144,4 +137,13 @@ func migrate(t *testing.T, driverUrl string) {
 	if err := d.Close(); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func dropTestTables(t *testing.T, db *sql.DB) {
+	if _, err := db.Exec(`
+				DROP TABLE IF EXISTS yolo;
+				DROP TABLE IF EXISTS ` + tableName + `;`); err != nil {
+		t.Fatal(err)
+	}
+
 }

--- a/driver/postgres/postgres_test.go
+++ b/driver/postgres/postgres_test.go
@@ -29,6 +29,24 @@ func TestMigrate(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	migrate(t, driverUrl)
+
+	if _, err := connection.Exec(`
+				DROP TABLE IF EXISTS yolo;
+				DROP TABLE IF EXISTS ` + tableName + `;`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Make an old-style `int` version column that we'll have to upgrade.
+	_, err = connection.Exec("CREATE TABLE IF NOT EXISTS " + tableName + " (version int not null primary key)")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	migrate(t, driverUrl)
+}
+
+func migrate(t *testing.T, driverUrl string) {
 	d := &Driver{}
 	if err := d.Initialize(driverUrl); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Depends on #2.

With this patch, folks who were using the mattes/migrate version of this tool can switch to this without having to do extra work.

They have 32-bit bit versions in their PostgreSQL and MySQL database that this tool can upgrade to 64-bit on its first check that the migration version table exists. Only those two databases seem to need their schema updated
