### PR TITLE
WIP: Add Apache Phoenix driver.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Migrate Changelog
 
+## v1.4.0 - 2016-10-01
+
+* Add Apache Phoenix driver.
+
 ## v1.3.1 - 2016-08-16
 
-* make mysql driver aware of SSL certificates for TLS connection by scanning ENV variables (https://github.com/mattes/migrate/pull/117/files)
+* Make mysql driver aware of SSL certificates for TLS connection by scanning ENV variables (https://github.com/mattes/migrate/pull/117/files)
 
 ## v1.3.0 - 2016-08-15
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ go-test:
     - postgres
     - mysql
     - cassandra
+    - phoenix
 go-build:
   <<: *go
   command: sh -c 'go get -v && go build -ldflags ''-s'' -o migrater'
@@ -24,3 +25,5 @@ mysql:
     MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
 cassandra:
   image: cassandra:2.2
+phoenix:
+    image: boostport/hbase-phoenix-all-in-one:1.2.3-4.8.1

--- a/driver/phoenix/README.md
+++ b/driver/phoenix/README.md
@@ -1,0 +1,22 @@
+# Apache Phoenix Driver
+
+* Runs migrations in transactions.
+  That means that if a migration failes, it will be safely rolled back.
+* Tries to return helpful error messages.
+* Stores migration version details in table ``schema_migrations``.
+  This table will be auto-generated.
+
+
+## Usage
+
+```bash
+migrate -url phoenix://host:port/schema -path ./db/migrations create add_field_to_table
+migrate -url phoenix://host:port/schema -path ./db/migrations up
+migrate help # for more info
+```
+
+See full [DSN (Data Source Name) documentation](https://github.com/Boostport/avatica#dsn-data-source-name).
+
+## Authors
+
+* Francis Chuang, https://github.com/F21, https://github.com/Boostport

--- a/driver/phoenix/phoenix.go
+++ b/driver/phoenix/phoenix.go
@@ -1,0 +1,208 @@
+// Package phoenix implements the Driver interface.
+package phoenix
+
+import (
+	"bufio"
+	"bytes"
+	"database/sql"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/Boostport/avatica"
+	"github.com/gemnasium/migrate/driver"
+	"github.com/gemnasium/migrate/file"
+	"github.com/gemnasium/migrate/migrate/direction"
+	"strings"
+)
+
+type Driver struct {
+	db *sql.DB
+}
+
+const tableName = "schema_migrations"
+
+func (driver *Driver) Initialize(url string) error {
+
+	urlWithoutScheme := strings.SplitN(url, "phoenix://", 2)
+
+	if len(urlWithoutScheme) != 2 {
+		return errors.New("invalid phoenix:// scheme")
+	}
+
+	db, err := sql.Open("avatica", "http://"+urlWithoutScheme[1])
+
+	if err != nil {
+		return err
+	}
+
+	if err := db.Ping(); err != nil {
+		return err
+	}
+
+	driver.db = db
+
+	if err := driver.ensureVersionTableExists(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (driver *Driver) Close() error {
+	if err := driver.db.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (driver *Driver) ensureVersionTableExists() error {
+	_, err := driver.db.Exec("CREATE TABLE IF NOT EXISTS " + tableName + " (version bigint not null primary key)")
+	return err
+}
+
+func (driver *Driver) FilenameExtension() string {
+	return "sql"
+}
+
+func (driver *Driver) Migrate(f file.File, pipe chan interface{}) {
+	defer close(pipe)
+	pipe <- f
+
+	tx, err := driver.db.Begin()
+	if err != nil {
+		pipe <- err
+		return
+	}
+
+	if f.Direction == direction.Up {
+		if _, err := tx.Exec("INSERT INTO "+tableName+" (version) VALUES (?)", f.Version); err != nil {
+			pipe <- err
+			if err := tx.Rollback(); err != nil {
+				pipe <- err
+			}
+			return
+		}
+	} else if f.Direction == direction.Down {
+		if _, err := tx.Exec("DELETE FROM "+tableName+" WHERE version=?", f.Version); err != nil {
+			pipe <- err
+			if err := tx.Rollback(); err != nil {
+				pipe <- err
+			}
+			return
+		}
+	}
+
+	if err := f.ReadContent(); err != nil {
+		pipe <- err
+		return
+	}
+
+	// Phoenix does not support multiple statements, so we need to do this.
+	sqlStmts := bytes.Split(f.Content, []byte(";"))
+
+	for _, sqlStmt := range sqlStmts {
+
+		sqlStmt = bytes.TrimSpace(sqlStmt)
+
+		if len(sqlStmt) > 0 {
+			if _, err := tx.Exec(string(sqlStmt)); err != nil {
+
+				avaticaErr, isErr := err.(*avatica.ResponseError)
+
+				if isErr {
+					re, err := regexp.Compile(`at line ([0-9]+)`)
+
+					if err != nil {
+						pipe <- err
+						if err := tx.Rollback(); err != nil {
+							pipe <- err
+						}
+					}
+
+					var lineNo int
+					lineNoRe := re.FindStringSubmatch(avaticaErr.ErrorMessage)
+
+					if len(lineNoRe) == 2 {
+						lineNo, err = strconv.Atoi(lineNoRe[1])
+					}
+
+					if err == nil {
+
+						// get white-space offset
+						wsLineOffset := 0
+						b := bufio.NewReader(bytes.NewBuffer(sqlStmt))
+						for {
+							line, _, err := b.ReadLine()
+							if err != nil {
+								break
+							}
+							if bytes.TrimSpace(line) == nil {
+								wsLineOffset += 1
+							} else {
+								break
+							}
+						}
+
+						message := avaticaErr.Error()
+						message = re.ReplaceAllString(message, fmt.Sprintf("at line %v", lineNo+wsLineOffset))
+
+						errorPart := file.LinesBeforeAndAfter(sqlStmt, lineNo, 5, 5, true)
+						pipe <- errors.New(fmt.Sprintf("%s\n\n%s", message, string(errorPart)))
+					} else {
+						pipe <- errors.New(avaticaErr.Error())
+					}
+
+					if err := tx.Rollback(); err != nil {
+						pipe <- err
+					}
+
+					return
+				}
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		pipe <- err
+		return
+	}
+}
+
+func (driver *Driver) Version() (file.Version, error) {
+	var version file.Version
+	err := driver.db.QueryRow("SELECT version FROM " + tableName + " ORDER BY version DESC LIMIT 1").Scan(&version)
+	switch {
+	case err == sql.ErrNoRows:
+		return 0, nil
+	case err != nil:
+		return 0, err
+	default:
+		return version, nil
+	}
+}
+
+func (driver *Driver) Versions() (file.Versions, error) {
+	versions := file.Versions{}
+
+	rows, err := driver.db.Query("SELECT version FROM " + tableName + " ORDER BY version DESC")
+	if err != nil {
+		return versions, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var version file.Version
+		err := rows.Scan(&version)
+		if err != nil {
+			return versions, err
+		}
+		versions = append(versions, version)
+	}
+	err = rows.Err()
+	return versions, err
+}
+
+func init() {
+	driver.RegisterDriver("phoenix", &Driver{})
+}

--- a/driver/phoenix/phoenix_test.go
+++ b/driver/phoenix/phoenix_test.go
@@ -1,0 +1,150 @@
+package phoenix
+
+import (
+	"database/sql"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gemnasium/migrate/file"
+	"github.com/gemnasium/migrate/migrate/direction"
+	pipep "github.com/gemnasium/migrate/pipe"
+)
+
+// TestMigrate runs some additional tests on Migrate().
+// Basic testing is already done in migrate/migrate_test.go
+func TestMigrate(t *testing.T) {
+	host := os.Getenv("PHOENIX_PORT_8765_TCP_ADDR")
+	port := os.Getenv("PHOENIX_PORT_8765_TCP_PORT")
+	driverUrl := "phoenix://" + host + ":" + port + "/migratetest?transactionIsolation=4"
+
+	// prepare clean database
+	connection, err := sql.Open("avatica", strings.SplitN(driverUrl, "phoenix://", 2)[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dropTestTables(t, connection)
+
+	migrate(t, driverUrl)
+
+	dropTestTables(t, connection)
+
+	_, err = connection.Exec("CREATE TABLE IF NOT EXISTS " + tableName + " (version bigint not null primary key);")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	migrate(t, driverUrl)
+}
+
+func migrate(t *testing.T, driverUrl string) {
+	d := &Driver{}
+
+	if err := d.Initialize(driverUrl); err != nil {
+		t.Fatal(err)
+	}
+
+	files := []file.File{
+		{
+			Path:      "/foobar",
+			FileName:  "20060102150405_foobar.up.sql",
+			Version:   20060102150405,
+			Name:      "foobar",
+			Direction: direction.Up,
+			Content: []byte(`
+        CREATE TABLE yolo (
+          id int(11) not null primary key
+        );
+
+				CREATE TABLE yolo1 (
+				  id int(11) not null primary key
+				);
+      `),
+		},
+		{
+			Path:      "/foobar",
+			FileName:  "20060102150405_foobar.down.sql",
+			Version:   20060102150405,
+			Name:      "foobar",
+			Direction: direction.Down,
+			Content: []byte(`
+        DROP TABLE yolo;
+      `),
+		},
+		{
+			Path:      "/foobar",
+			FileName:  "20070000000000_foobar.up.sql",
+			Version:   20070000000000,
+			Name:      "foobar",
+			Direction: direction.Up,
+			Content: []byte(`
+
+      	// a comment
+				CREATE TABLE error (
+          id THIS WILL CAUSE AN ERROR
+        );
+      `),
+		},
+	}
+
+	pipe := pipep.New()
+	go d.Migrate(files[0], pipe)
+	errs := pipep.ReadErrors(pipe)
+	if len(errs) > 0 {
+		t.Fatal(errs)
+	}
+
+	version, err := d.Version()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if version != 20060102150405 {
+		t.Errorf("Expected version to be: %d, got: %d", 20060102150405, version)
+	}
+
+	// Check versions applied in DB
+	expectedVersions := file.Versions{20060102150405}
+	versions, err := d.Versions()
+	if err != nil {
+		t.Errorf("Could not fetch versions: %s", err)
+	}
+
+	pipe = pipep.New()
+	go d.Migrate(files[1], pipe)
+	errs = pipep.ReadErrors(pipe)
+	if len(errs) > 0 {
+		t.Fatal(errs)
+	}
+
+	pipe = pipep.New()
+	go d.Migrate(files[2], pipe)
+	errs = pipep.ReadErrors(pipe)
+	if len(errs) == 0 {
+		t.Error("Expected test case to fail")
+	}
+
+	// Check versions applied in DB
+	expectedVersions = file.Versions{}
+	versions, err = d.Versions()
+	if err != nil {
+		t.Errorf("Could not fetch versions: %s", err)
+	}
+
+	if !reflect.DeepEqual(versions, expectedVersions) {
+		t.Errorf("Expected versions to be: %v, got: %v", expectedVersions, versions)
+	}
+
+	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func dropTestTables(t *testing.T, db *sql.DB) {
+	if _, err := db.Exec(`DROP TABLE IF EXISTS yolo, yolo1, ` + tableName); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This PR adds an Apache Phoenix driver, so that migrate can be used to perform migrations for schemes stored in Apache Phoenix/HBase.
