### PR TITLE
Fixing migrate sqlite3 for multiple statements in a single file

### DIFF
--- a/driver/sqlite3/sqlite3.go
+++ b/driver/sqlite3/sqlite3.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gemnasium/migrate/driver"
 	"github.com/gemnasium/migrate/file"
 	"github.com/gemnasium/migrate/migrate/direction"
-	_ "github.com/mattn/go-sqlite3"
+	"github.com/mattn/go-sqlite3"
 )
 
 type Driver struct {

--- a/driver/sqlite3/sqlite3.go
+++ b/driver/sqlite3/sqlite3.go
@@ -98,7 +98,7 @@ func (driver *Driver) Migrate(f file.File, pipe chan interface{}) {
 			if isErr {
 				// The sqlite3 library only provides error codes, not position information. Output what we do know.
 				pipe <- fmt.Errorf("SQLite Error (%s); Extended (%s)\nError: %s",
-					sqliteErr.Code.Error(), sqliteErr.ExtendedCode.Error(), sqliteErr.Error()))
+					sqliteErr.Code.Error(), sqliteErr.ExtendedCode.Error(), sqliteErr.Error())
 			} else {
 				pipe <- fmt.Errorf("An error occurred when running query [%q]: %v", query, err)
 			}

--- a/driver/sqlite3/sqlite3_test.go
+++ b/driver/sqlite3/sqlite3_test.go
@@ -1,7 +1,8 @@
 package sqlite3
 
 import (
-	"database/sql"
+	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -13,22 +14,14 @@ import (
 // TestMigrate runs some additional tests on Migrate()
 // Basic testing is already done in migrate/migrate_test.go
 func TestMigrate(t *testing.T) {
-	driverFile := ":memory:"
-	driverUrl := "sqlite3://" + driverFile
-
-	// prepare clean database
-	connection, err := sql.Open("sqlite3", driverFile)
+	f, err := ioutil.TempFile(os.TempDir(), "migrate_test")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := connection.Exec(`
-							DROP TABLE IF EXISTS yolo;
-							DROP TABLE IF EXISTS ` + tableName + `;`); err != nil {
-		t.Fatal(err)
-	}
+	defer os.Remove(f.Name())
 
 	d := &Driver{}
-	if err := d.Initialize(driverUrl); err != nil {
+	if err := d.Initialize("sqlite3://" + f.Name()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -47,6 +40,17 @@ func TestMigrate(t *testing.T) {
 		},
 		{
 			Path:      "/foobar",
+			FileName:  "20060102200405_alter_table.up.sql",
+			Version:   20060102200405,
+			Name:      "alter_table",
+			Direction: direction.Up,
+			Content: []byte(`
+				ALTER TABLE yolo ADD COLUMN data1 VCHAR(255);
+				ALTER TABLE yolo ADD COLUMN data2 VCHAR(255);
+			`),
+		},
+		{
+			Path:      "/foobar",
 			FileName:  "20060102150405_foobar.down.sql",
 			Version:   20060102150405,
 			Name:      "foobar",
@@ -57,9 +61,9 @@ func TestMigrate(t *testing.T) {
 		},
 		{
 			Path:      "/foobar",
-			FileName:  "20060102150406_foobar.up.sql",
-			Version:   20060102150406,
-			Name:      "foobar",
+			FileName:  "20060102150406_failing.up.sql",
+			Version:   20060103200406,
+			Name:      "failing",
 			Direction: direction.Down,
 			Content: []byte(`
 				CREATE TABLE error (
@@ -80,16 +84,18 @@ func TestMigrate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	if version != 20060102150405 {
-		t.Errorf("Expected version to be: %d, got: %d", 20060102150405, version)
+	if version != files[0].Version {
+		t.Errorf("Expected version to be: %d, got: %d", files[0].Version, version)
 	}
 
-	// Check versions applied in DB
-	expectedVersions := file.Versions{20060102150405}
+	// Check versions applied in DB.
+	expectedVersions := file.Versions{files[0].Version}
 	versions, err := d.Versions()
 	if err != nil {
 		t.Errorf("Could not fetch versions: %s", err)
+	}
+	if !reflect.DeepEqual(versions, expectedVersions) {
+		t.Errorf("Expected versions to be: %v, got: %v", expectedVersions, versions)
 	}
 
 	pipe = pipep.New()
@@ -98,26 +104,62 @@ func TestMigrate(t *testing.T) {
 	if len(errs) > 0 {
 		t.Fatal(errs)
 	}
+	if _, err := d.db.Query("SELECT id, data1, data2 FROM yolo"); err != nil {
+		t.Errorf("Sequental migration failed: %v", err)
+	}
+
+	// Check versions applied in DB.
+	expectedVersions = file.Versions{files[1].Version, files[0].Version}
+	versions, err = d.Versions()
+	if err != nil {
+		t.Errorf("Could not fetch versions: %s", err)
+	}
+	if !reflect.DeepEqual(versions, expectedVersions) {
+		t.Errorf("Expected versions to be: %v, got: %v", expectedVersions, versions)
+	}
+
+	if _, err := d.db.Query("SELECT * FROM schema_migration"); err != nil {
+		t.Errorf("F: %v", err)
+	}
 
 	pipe = pipep.New()
 	go d.Migrate(files[2], pipe)
+	errs = pipep.ReadErrors(pipe)
+	if len(errs) > 0 {
+		t.Fatal(errs)
+	}
+
+	pipe = pipep.New()
+	go d.Migrate(files[3], pipe)
 	errs = pipep.ReadErrors(pipe)
 	if len(errs) == 0 {
 		t.Error("Expected test case to fail")
 	}
 
-	// Check versions applied in DB
-	expectedVersions = file.Versions{}
-	versions, err = d.Versions()
-	if err != nil {
-		t.Errorf("Could not fetch versions: %s", err)
-	}
-
-	if !reflect.DeepEqual(versions, expectedVersions) {
-		t.Errorf("Expected versions to be: %v, got: %v", expectedVersions, versions)
-	}
-
 	if err := d.Close(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestSplitStatements(t *testing.T) {
+	testCases := []struct {
+		name string
+		q    string
+		want []string
+	}{
+		{"empty noop", "", []string{}},
+		{"single query", "CREATE TABLE a id INT;", []string{"CREATE TABLE a id INT;"}},
+		{"multiple queries", "CREATE TABLE a id INT; CREATE TABLE b id INT; ",
+			[]string{"CREATE TABLE a id INT;", "CREATE TABLE b id INT;"},
+		},
+		{"with line breaks", "CREATE TABLE a id INT;\n\n\t CREATE TABLE b id INT; ",
+			[]string{"CREATE TABLE a id INT;", "CREATE TABLE b id INT;"},
+		},
+	}
+	for _, tc := range testCases {
+		got := splitStatements(tc.q)
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("(%s) splitStatements(%q) = %q, want: %q", tc.name, tc.q, got, tc.want)
+		}
 	}
 }

--- a/driver/sqlite3/sqlite3_test.go
+++ b/driver/sqlite3/sqlite3_test.go
@@ -105,7 +105,7 @@ func TestMigrate(t *testing.T) {
 		t.Fatal(errs)
 	}
 	if _, err := d.db.Query("SELECT id, data1, data2 FROM yolo"); err != nil {
-		t.Errorf("Sequental migration failed: %v", err)
+		t.Errorf("Sequential migration failed: %v", err)
 	}
 
 	// Check versions applied in DB.
@@ -116,10 +116,6 @@ func TestMigrate(t *testing.T) {
 	}
 	if !reflect.DeepEqual(versions, expectedVersions) {
 		t.Errorf("Expected versions to be: %v, got: %v", expectedVersions, versions)
-	}
-
-	if _, err := d.db.Query("SELECT * FROM schema_migration"); err != nil {
-		t.Errorf("F: %v", err)
 	}
 
 	pipe = pipep.New()


### PR DESCRIPTION
Existing implementation only executes the first statement for sqlite which
allows only one change per migration and not practical.

Also tests attempt to remove(?) tables with multi-line statement which wouldn't
work. Luckily that part of the test is a noop.