### PR TITLE
Driver for Crate.io Database

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ go-test:
     - postgres
     - mysql
     - cassandra
+    - crate
 go-build:
   <<: *go
   command: sh -c 'go get -v && go build -ldflags ''-s'' -o migrater'
@@ -24,3 +25,5 @@ mysql:
     MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
 cassandra:
   image: cassandra:2.2
+crate:
+  image: crate

--- a/driver/crate/README.md
+++ b/driver/crate/README.md
@@ -1,0 +1,15 @@
+# Crate driver
+
+This is a driver for the [Crate](https://crate.io) database. It is based on the Crate
+sql driver by [herenow](https://github.com/herenow/go-crate).
+
+This driver does not use transactions! This is not a limitation of the driver, but a 
+limitation of Crate. So handle situations with failed migrations with care!
+
+## Usage
+
+```bash
+migrate -url http://host:port -path ./db/migrations create add_field_to_table
+migrate -url http://host:port -path ./db/migrations up
+migrate help # for more info
+```

--- a/driver/crate/crate.go
+++ b/driver/crate/crate.go
@@ -23,6 +23,7 @@ type Driver struct {
 const tableName = "schema_migrations"
 
 func (driver *Driver) Initialize(url string) error {
+	url = strings.Replace(url, "crate", "http", 1)
 	db, err := sql.Open("crate", url)
 	if err != nil {
 		return err

--- a/driver/crate/crate.go
+++ b/driver/crate/crate.go
@@ -1,0 +1,105 @@
+// Package crate implements a driver for the Crate.io database
+package crate
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	_ "github.com/herenow/go-crate"
+	"github.com/mattes/migrate/driver"
+	"github.com/mattes/migrate/file"
+	"github.com/mattes/migrate/migrate/direction"
+)
+
+func init() {
+	driver.RegisterDriver("crate", &Driver{})
+}
+
+type Driver struct {
+	db *sql.DB
+}
+
+const tableName = "schema_migrations"
+
+func (driver *Driver) Initialize(url string) error {
+	db, err := sql.Open("crate", url)
+	if err != nil {
+		return err
+	}
+	if err := db.Ping(); err != nil {
+		return err
+	}
+	driver.db = db
+
+	if err := driver.ensureVersionTableExists(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (driver *Driver) Close() error {
+	if err := driver.db.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (driver *Driver) FilenameExtension() string {
+	return "sql"
+}
+
+func (driver *Driver) Version() (uint64, error) {
+	var version uint64
+	err := driver.db.QueryRow("SELECT version FROM " + tableName + " ORDER BY version DESC LIMIT 1").Scan(&version)
+	switch {
+	case err == sql.ErrNoRows:
+		return 0, nil
+	case err != nil:
+		return 0, err
+	default:
+		return version, nil
+	}
+}
+
+func (driver *Driver) Migrate(f file.File, pipe chan interface{}) {
+	defer close(pipe)
+	pipe <- f
+
+	if err := f.ReadContent(); err != nil {
+		pipe <- err
+		return
+	}
+
+	lines := strings.Split(string(f.Content), ";")
+	for _, line := range lines {
+		query := strings.TrimSpace(line)
+		query = strings.Replace(query, ";", "", -1)
+		if query != "" {
+			_, err := driver.db.Exec(query)
+			if err != nil {
+				pipe <- err
+				return
+			}
+		}
+	}
+
+	if f.Direction == direction.Up {
+		if _, err := driver.db.Exec("INSERT INTO "+tableName+" (version) VALUES (?)", f.Version); err != nil {
+			pipe <- err
+			return
+		}
+	} else if f.Direction == direction.Down {
+		if _, err := driver.db.Exec("DELETE FROM "+tableName+" WHERE version=?", f.Version); err != nil {
+			pipe <- err
+			return
+		}
+	}
+}
+
+func (driver *Driver) ensureVersionTableExists() error {
+	if _, err := driver.db.Exec(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (version INTEGER PRIMARY KEY)", tableName)); err != nil {
+		return err
+	}
+	return nil
+}

--- a/driver/crate/crate.go
+++ b/driver/crate/crate.go
@@ -72,16 +72,12 @@ func (driver *Driver) Migrate(f file.File, pipe chan interface{}) {
 		return
 	}
 
-	lines := strings.Split(string(f.Content), ";")
+	lines := splitContent(string(f.Content))
 	for _, line := range lines {
-		query := strings.TrimSpace(line)
-		query = strings.Replace(query, ";", "", -1)
-		if query != "" {
-			_, err := driver.db.Exec(query)
-			if err != nil {
-				pipe <- err
-				return
-			}
+		_, err := driver.db.Exec(line)
+		if err != nil {
+			pipe <- err
+			return
 		}
 	}
 
@@ -96,6 +92,19 @@ func (driver *Driver) Migrate(f file.File, pipe chan interface{}) {
 			return
 		}
 	}
+}
+
+func splitContent(content string) []string {
+	lines := strings.Split(content, ";")
+	resultLines := make([]string, 0, len(lines))
+	for i, line := range lines {
+		line = strings.Replace(lines[i], ";", "", -1)
+		line = strings.TrimSpace(line)
+		if line != "" {
+			resultLines = append(resultLines, line)
+		}
+	}
+	return resultLines
 }
 
 func (driver *Driver) ensureVersionTableExists() error {

--- a/driver/crate/crate.go
+++ b/driver/crate/crate.go
@@ -131,7 +131,7 @@ func splitContent(content string) []string {
 }
 
 func (driver *Driver) ensureVersionTableExists() error {
-	if _, err := driver.db.Exec(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (version INTEGER PRIMARY KEY)", tableName)); err != nil {
+	if _, err := driver.db.Exec(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (version LONG PRIMARY KEY)", tableName)); err != nil {
 		return err
 	}
 	return nil

--- a/driver/crate/crate.go
+++ b/driver/crate/crate.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gemnasium/migrate/driver"
+	"github.com/gemnasium/migrate/file"
+	"github.com/gemnasium/migrate/migrate/direction"
 	_ "github.com/herenow/go-crate"
-	"github.com/mattes/migrate/driver"
-	"github.com/mattes/migrate/file"
-	"github.com/mattes/migrate/migrate/direction"
 )
 
 func init() {

--- a/driver/crate/crate_test.go
+++ b/driver/crate/crate_test.go
@@ -1,0 +1,87 @@
+package crate
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/mattes/migrate/file"
+	"github.com/mattes/migrate/migrate/direction"
+	pipep "github.com/mattes/migrate/pipe"
+)
+
+func TestMigrate(t *testing.T) {
+	host := os.Getenv("CRATE_PORT_4200_TCP_ADDR")
+	port := os.Getenv("CRATE_PORT_4200_TCP_PORT")
+
+	url := fmt.Sprintf("http://%s:%s", host, port)
+
+	driver := &Driver{}
+
+	if err := driver.Initialize(url); err != nil {
+		t.Fatal(err)
+	}
+
+	successFiles := []file.File{
+		{
+			Path:      "/foobar",
+			FileName:  "001_foobar.up.sql",
+			Version:   1,
+			Name:      "foobar",
+			Direction: direction.Up,
+			Content: []byte(`
+                CREATE TABLE yolo (
+                    id integer primary key,
+                    msg string
+                );
+            `),
+		},
+		{
+			Path:      "/foobar",
+			FileName:  "002_foobar.down.sql",
+			Version:   1,
+			Name:      "foobar",
+			Direction: direction.Down,
+			Content: []byte(`
+                DROP TABLE yolo;
+            `),
+		},
+	}
+
+	failFiles := []file.File{
+		{
+			Path:      "/foobar",
+			FileName:  "002_foobar.up.sql",
+			Version:   2,
+			Name:      "foobar",
+			Direction: direction.Up,
+			Content: []byte(`
+                CREATE TABLE error (
+                    id THIS WILL CAUSE AN ERROR
+                )
+            `),
+		},
+	}
+
+	for _, file := range successFiles {
+		pipe := pipep.New()
+		go driver.Migrate(file, pipe)
+		errs := pipep.ReadErrors(pipe)
+		if len(errs) > 0 {
+			t.Fatal(errs)
+		}
+	}
+
+	for _, file := range failFiles {
+		pipe := pipep.New()
+		go driver.Migrate(file, pipe)
+		errs := pipep.ReadErrors(pipe)
+		if len(errs) == 0 {
+			t.Fatal("Migration should have failed but succeeded")
+		}
+	}
+
+	if err := driver.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/driver/crate/crate_test.go
+++ b/driver/crate/crate_test.go
@@ -14,7 +14,7 @@ func TestMigrate(t *testing.T) {
 	host := os.Getenv("CRATE_PORT_4200_TCP_ADDR")
 	port := os.Getenv("CRATE_PORT_4200_TCP_PORT")
 
-	url := fmt.Sprintf("http://%s:%s", host, port)
+	url := fmt.Sprintf("crate://%s:%s", host, port)
 
 	driver := &Driver{}
 

--- a/driver/crate/crate_test.go
+++ b/driver/crate/crate_test.go
@@ -10,6 +10,30 @@ import (
 	pipep "github.com/mattes/migrate/pipe"
 )
 
+func TestContentSplit(t *testing.T) {
+	content := `CREATE TABLE users (user_id STRING primary key, first_name STRING, last_name STRING, email STRING, password_hash STRING) CLUSTERED INTO 3 shards WITH (number_of_replicas = 0);
+CREATE TABLE units (unit_id STRING primary key, name STRING, members array(string)) CLUSTERED INTO 3 shards WITH (number_of_replicas = 0);
+CREATE TABLE available_connectors (technology_id STRING primary key, description STRING, icon STRING, link STRING, configuration_parameters array(object as (name STRING, type STRING))) CLUSTERED INTO 3 shards WITH (number_of_replicas = 0);
+	`
+
+	lines := splitContent(content)
+	if len(lines) != 3 {
+		t.Errorf("Expected 3 lines, but got %d", len(lines))
+	}
+
+	if lines[0] != "CREATE TABLE users (user_id STRING primary key, first_name STRING, last_name STRING, email STRING, password_hash STRING) CLUSTERED INTO 3 shards WITH (number_of_replicas = 0)" {
+		t.Error("Line does not match expected output")
+	}
+
+	if lines[1] != "CREATE TABLE units (unit_id STRING primary key, name STRING, members array(string)) CLUSTERED INTO 3 shards WITH (number_of_replicas = 0)" {
+		t.Error("Line does not match expected output")
+	}
+
+	if lines[2] != "CREATE TABLE available_connectors (technology_id STRING primary key, description STRING, icon STRING, link STRING, configuration_parameters array(object as (name STRING, type STRING))) CLUSTERED INTO 3 shards WITH (number_of_replicas = 0)" {
+		t.Error("Line does not match expected output")
+	}
+}
+
 func TestMigrate(t *testing.T) {
 	host := os.Getenv("CRATE_PORT_4200_TCP_ADDR")
 	port := os.Getenv("CRATE_PORT_4200_TCP_PORT")

--- a/driver/crate/crate_test.go
+++ b/driver/crate/crate_test.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/mattes/migrate/file"
-	"github.com/mattes/migrate/migrate/direction"
-	pipep "github.com/mattes/migrate/pipe"
+	"github.com/gemnasium/migrate/file"
+	"github.com/gemnasium/migrate/migrate/direction"
+	pipep "github.com/gemnasium/migrate/pipe"
 )
 
 func TestContentSplit(t *testing.T) {

--- a/driver/crate/crate_test.go
+++ b/driver/crate/crate_test.go
@@ -49,8 +49,8 @@ func TestMigrate(t *testing.T) {
 	successFiles := []file.File{
 		{
 			Path:      "/foobar",
-			FileName:  "001_foobar.up.sql",
-			Version:   1,
+			FileName:  "20161122192905_foobar.up.sql",
+			Version:   20161122192905,
 			Name:      "foobar",
 			Direction: direction.Up,
 			Content: []byte(`
@@ -62,8 +62,8 @@ func TestMigrate(t *testing.T) {
 		},
 		{
 			Path:      "/foobar",
-			FileName:  "002_foobar.down.sql",
-			Version:   1,
+			FileName:  "20161122192905_foobar.down.sql",
+			Version:   20161122192905,
 			Name:      "foobar",
 			Direction: direction.Down,
 			Content: []byte(`
@@ -75,8 +75,8 @@ func TestMigrate(t *testing.T) {
 	failFiles := []file.File{
 		{
 			Path:      "/foobar",
-			FileName:  "002_foobar.up.sql",
-			Version:   2,
+			FileName:  "20161122193005_foobar.up.sql",
+			Version:   20161122193005,
 			Name:      "foobar",
 			Direction: direction.Up,
 			Content: []byte(`

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fatih/color"
 	_ "github.com/gemnasium/migrate/driver/bash"
 	_ "github.com/gemnasium/migrate/driver/cassandra"
+	_ "github.com/gemnasium/migrate/driver/crate"
 	_ "github.com/gemnasium/migrate/driver/mysql"
 	_ "github.com/gemnasium/migrate/driver/postgres"
 	_ "github.com/gemnasium/migrate/driver/sqlite3"


### PR DESCRIPTION
This Pull Request implements an experimental driver (for the same reasons as the MySQL driver) for the Crate.io database.
Since Crate.io doesn't support transactions this driver can't use transactions and it is possible that you are left with incomplete migrations on errors. But this is a limitation of the database itself not of this driver.
I originally tried to contribute this mattes/migrate but since project seems to be dead, I ported my changes to this fork.