### PR TITLE
cassandra: disable initial hosts lookup configuration option

### DIFF
--- a/driver/cassandra/README.md
+++ b/driver/cassandra/README.md
@@ -10,7 +10,9 @@ migrate help # for more info
 
 Url format
 - Authentication: `cassandra://username:password@host:port/keyspace`
-- Cassandra v3.x: `cassandra://host:port/keyspace?protocol=4`
+- Cassandra v3.x: `cassandra://host:port/keyspace?protocol=4&consistency=all&disable_init_host_lookup`
+
+> Cassandra in Docker users on a Mac: when using gcql + migrate, use the `disable_init_host_lookup` option in the connection URL. This will alleviate the issue of gocql trying to connect to internal docker IP addresses.
 
 ## Authors
 

--- a/driver/cassandra/cassandra.go
+++ b/driver/cassandra/cassandra.go
@@ -56,6 +56,10 @@ func (driver *Driver) Initialize(rawurl string) error {
 		cluster.ProtoVersion = protoversion
 	}
 
+	if _, ok := u.Query()["disable_init_host_lookup"]; ok {
+		cluster.DisableInitialHostLookup = true
+	}
+
 	// Check if url user struct is null
 	if u.User != nil {
 		password, passwordSet := u.User.Password()


### PR DESCRIPTION
This is to alleviate the issue that arises where gocql tries to connect to internal IP addresses broadcast by Cassandra when run within a docker container in something like docker-machine or docker for mac. 

This adds `disable_init_host_lookup` as an option provided as a URL encoded query parameter.

See here https://github.com/gocql/gocql/issues/696

I wasted quite a bit of time tracking down why it took nearly 3 minutes every time migrate tried to obtain a session with cassandra XD

This basically stops Gocql attempting (when creating a session) to resolve other IP addresses other than the one provided using `-url`. Useful for running against a single local docker Cassandra or in a CI environment.