### PR TITLE
driver: fix: driver/mysql/mysql.go:89:23: undefined: mysql.MySQLWarnings

### DIFF
--- a/driver/mysql/mysql.go
+++ b/driver/mysql/mysql.go
@@ -86,7 +86,7 @@ func (driver *Driver) Close() error {
 func (driver *Driver) ensureVersionTableExists() error {
 	_, err := driver.db.Exec("CREATE TABLE IF NOT EXISTS " + tableName + " (version bigint not null primary key);")
 
-	if _, isWarn := err.(mysql.MySQLWarnings); err != nil && !isWarn {
+	if err != nil {
 		return err
 	}
 	r := driver.db.QueryRow("SELECT data_type FROM information_schema.columns where table_name = ? and column_name = 'version'", tableName)


### PR DESCRIPTION
compilation failed with:
  driver: fix: driver/mysql/mysql.go:89:23: undefined: mysql.MySQLWarnings

MySQLWarnings was removed from the mysql driver
(https://github.com/go-sql-driver/mysql/pull/676), remove it from
migrate